### PR TITLE
add function prototype for OlrxAPIGetRelay(...)

### DIFF
--- a/Include/olrxapi.h
+++ b/Include/olrxapi.h
@@ -710,6 +710,7 @@ const char* __stdcall OlrxAPIGetObjMemo( int nDeviceHnd );
 const char* __stdcall OlrxAPIGetObjTags( int nDeviceHnd );
 const char* __stdcall OlrxAPIGetOlrFileName();
 int __stdcall OlrxAPIGetPSCVoltage( int nDeviceHnd, double *dOut1, double *dOut2, int nStyle );
+int __stdcall OlrxAPIGetRelay( int nHndRlyGroup, int* nHndRelay );
 int __stdcall OlrxAPIGetRelayTime( int nRelayHnd, double dFactor, double *pTime, char* szDevice, int nTripOnly );
 int __stdcall OlrxAPIGetSCCurrent( int nDeviceHnd, double *dOut1, double *dOut2, int nStyle );
 int __stdcall OlrxAPIGetSCVoltage( int nDeviceHnd, double *dOut1, double *dOut2, int nStyle );


### PR DESCRIPTION
This PR adds a function prototype for OlrxAPIGetRelay.  I think this omission was just an oversight, as the definition appears to be in the library file and there is a definition in the python module.